### PR TITLE
ci: add release and deploy playground workflow

### DIFF
--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -1,0 +1,49 @@
+
+name: playground
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  playground:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v3
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+
+      - name: Install dependencies and build
+        working-directory: ./examples/sdk-demo-example
+        env:
+          BASE_PATH: /accelbyte-web-sdk
+          VITE_MODE: ${{ vars.VITE_MODE }}
+          VITE_SDK_BASE_URL: ${{ secrets.VITE_SDK_BASE_URL }}
+          VITE_CLIENT_ID: ${{ secrets.VITE_CLIENT_ID }}
+          VITE_NAMESPACE: ${{ secrets.VITE_NAMESPACE }}
+          VITE_REDIRECT_URI: ${{ secrets.VITE_REDIRECT_URI }}
+        run: |
+          yarn
+          yarn build
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./examples/sdk-demo-example/dist
+          # Publish only with the latest commit.
+          # Source: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-force-orphan-force_orphan.
+          force_orphan: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+
+      - run: yarn
+
+      - name: Create Release Pull Request
+        uses: changesets/action@v1
+        with:
+          publish: yarn changeset:tag
+          version: yarn changeset:version
+          commit: 'chore: version packages'
+          title: 'chore: version packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes
Add GitHub workflow for:

- Deploy Playground from `sdk-demo-example` to GitHub Pages
- Create Release Pull Request